### PR TITLE
Correct image scale in retina display.

### DIFF
--- a/transform/framework/FlipView.m
+++ b/transform/framework/FlipView.m
@@ -75,6 +75,7 @@
   backgroundColor:(UIColor *)aBackgroundColor
         textColor:(UIColor *)aTextColor 
 {
+    CGFloat scale = [[UIScreen mainScreen] scale];
     
     if ([super printText:tickerString usingImage:aImage backgroundColor:aBackgroundColor textColor:aTextColor]) {
         switch (self.animationType) {
@@ -140,9 +141,9 @@
                 shadowLayer4.transform = CATransform3DMakeRotation(M_PI, 1.0, 0, 0);
                 [flipLayer2 addSublayer:shadowLayer4];
                 
-                CGImageRef imageRef = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, 0, templateWidth, templateHeight/2));
+                CGImageRef imageRef = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, 0, templateWidth*scale, templateHeight*scale/2));
                 
-                CGImageRef imageRef2 = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, templateHeight/2, templateWidth, templateHeight/2));
+                CGImageRef imageRef2 = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, templateHeight*scale/2, templateWidth*scale, templateHeight*scale/2));
                 
                 [backLayer setContents:(id)imageRef];
                 [backLayer2 setContents:(id)imageRef2];
@@ -218,9 +219,9 @@
                 shadowLayer4.transform = CATransform3DMakeRotation(M_PI, 0, 1.0, 0);
                 [flipLayer2 addSublayer:shadowLayer4];
                 
-                CGImageRef imageRef = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(templateWidth/2, 0, templateWidth/2, templateHeight));
+                CGImageRef imageRef = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(templateWidth*scale/2, 0, templateWidth*scale/2, templateHeight*scale));
                 
-                CGImageRef imageRef2 = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, 0, templateWidth/2, templateHeight));
+                CGImageRef imageRef2 = CGImageCreateWithImageInRect([templateImage CGImage], CGRectMake(0, 0, templateWidth*scale/2, templateHeight*scale));
                 
                 [backLayer setContents:(id)imageRef2];
                 [backLayer2 setContents:(id)imageRef];

--- a/transform/framework/GenericAnimationView.m
+++ b/transform/framework/GenericAnimationView.m
@@ -92,6 +92,7 @@
     if (tickerString) {
         
         CALayer *backingLayer = [CALayer layer];
+        backingLayer.contentsGravity = kCAGravityResizeAspect;
         // set opaque to improve rendering speed
         backingLayer.opaque = YES;
         
@@ -110,6 +111,7 @@
         CATextLayer *label = [CATextLayer layer];
         // for crisp text, set text layer to screen resolution
         label.contentsScale = [[UIScreen mainScreen] scale];
+        label.contentsGravity = kCAGravityResizeAspect;
         label.string = tickerString;
         label.font = font;
         label.fontSize = fontSize;
@@ -126,9 +128,12 @@
         
         [backingLayer addSublayer:label];
         
-        UIGraphicsBeginImageContext(backingLayer.frame.size);
+        CGFloat scale = [[UIScreen mainScreen] scale];
+        CGSize size = CGSizeMake(backingLayer.frame.size.width*scale, backingLayer.frame.size.height*scale);
+        UIGraphicsBeginImageContextWithOptions(size, NO, scale);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        [backingLayer renderInContext:context];
         
-        [backingLayer renderInContext:UIGraphicsGetCurrentContext()];
         templateImage = UIGraphicsGetImageFromCurrentImageContext();
         
         UIGraphicsEndImageContext();
@@ -160,6 +165,7 @@
     layer.doubleSided = NO;
     layer.masksToBounds = YES;
     layer.doubleSided = NO;
+    layer.contentsGravity = kCAGravityResizeAspect;
     
     return layer;
 }


### PR DESCRIPTION
Fixed low resolution/blurry images in retina display. For that I used the UIGraphicsBeginImageContextWithOptions() function and also set the contentsGravity of most layers to kCAGravityResizeAspect so that it will automatically fit in the right scale. 
